### PR TITLE
feat:add grand total field in job card master ,change transporter and forwarder to supplier

### DIFF
--- a/petropipe/crud_events/job_card_master.py
+++ b/petropipe/crud_events/job_card_master.py
@@ -12,7 +12,8 @@ def auto_job_card(doc, method=None):
                 "customer": doc.customer or '',
                 "incoterm": doc.incoterm or '',
                 "sales_order": doc.name or '',
-                "company": doc.company or ''
+                "company": doc.company or '',
+                "grand_total": doc.grand_total or '',
             }, update_modified=True)
         except Exception:
             frappe.log_error(frappe.get_traceback(), "Job Card Master Update Failed")
@@ -24,6 +25,7 @@ def auto_job_card(doc, method=None):
             job_card_master.customer = doc.customer or ""
             job_card_master.incoterm = doc.incoterm or ""
             job_card_master.company = doc.company or ""
+            job_card_master.grand_total = doc.grand_total or ""
             job_card_master.insert(ignore_permissions=True)
         except DuplicateEntryError:
             existing_name = frappe.db.get_value( "Job Card Master",{"job_no": doc.job_no},"name")
@@ -32,7 +34,8 @@ def auto_job_card(doc, method=None):
                     "customer": doc.customer or "",
                     "incoterm": doc.incoterm or "",
                     "sales_order": doc.name or "",
-                    "company": doc.company or ""
+                    "company": doc.company or "",
+                    "grand_total": doc.grand_total or ""
                 }, update_modified=True)
 
         except Exception:

--- a/petropipe/crud_events/job_card_master.py
+++ b/petropipe/crud_events/job_card_master.py
@@ -13,7 +13,7 @@ def auto_job_card(doc, method=None):
                 "incoterm": doc.incoterm or '',
                 "sales_order": doc.name or '',
                 "company": doc.company or '',
-                "grand_total": doc.grand_total or '',
+                "grand_total": doc.grand_total or 0
             }, update_modified=True)
         except Exception:
             frappe.log_error(frappe.get_traceback(), "Job Card Master Update Failed")
@@ -35,7 +35,7 @@ def auto_job_card(doc, method=None):
                     "incoterm": doc.incoterm or "",
                     "sales_order": doc.name or "",
                     "company": doc.company or "",
-                    "grand_total": doc.grand_total or ""
+                    "grand_total": doc.grand_total or 0
                 }, update_modified=True)
 
         except Exception:

--- a/petropipe/crud_events/job_card_master.py
+++ b/petropipe/crud_events/job_card_master.py
@@ -25,7 +25,7 @@ def auto_job_card(doc, method=None):
             job_card_master.customer = doc.customer or ""
             job_card_master.incoterm = doc.incoterm or ""
             job_card_master.company = doc.company or ""
-            job_card_master.grand_total = doc.grand_total or ""
+            job_card_master.grand_total = doc.grand_total or 0
             job_card_master.insert(ignore_permissions=True)
         except DuplicateEntryError:
             existing_name = frappe.db.get_value( "Job Card Master",{"job_no": doc.job_no},"name")

--- a/petropipe/crud_events/job_card_master.py
+++ b/petropipe/crud_events/job_card_master.py
@@ -1,10 +1,11 @@
 import frappe
+from frappe.exceptions import DuplicateEntryError
 
 def auto_job_card(doc, method=None):
     if not doc.job_no:
         return
     
-    job_card_name = frappe.db.get_value("Job Card Master", {"job_no": doc.job_no}, "name")
+    job_card_name = frappe.db.exists("Job Card Master",{"job_no": doc.job_no})
     if job_card_name:
         try:
             frappe.db.set_value("Job Card Master", job_card_name, {
@@ -20,10 +21,20 @@ def auto_job_card(doc, method=None):
             job_card_master = frappe.new_doc("Job Card Master")
             job_card_master.sales_order = doc.name
             job_card_master.job_no = doc.job_no
-            job_card_master.customer = doc.customer or ''
-            job_card_master.incoterm = doc.incoterm or ''
-            job_card_master.company = doc.company or ''
+            job_card_master.customer = doc.customer or ""
+            job_card_master.incoterm = doc.incoterm or ""
+            job_card_master.company = doc.company or ""
             job_card_master.insert(ignore_permissions=True)
+        except DuplicateEntryError:
+            existing_name = frappe.db.get_value( "Job Card Master",{"job_no": doc.job_no},"name")
+            if existing_name:
+                frappe.db.set_value("Job Card Master", existing_name, {
+                    "customer": doc.customer or "",
+                    "incoterm": doc.incoterm or "",
+                    "sales_order": doc.name or "",
+                    "company": doc.company or ""
+                }, update_modified=True)
+
         except Exception:
-            frappe.log_error(frappe.get_traceback(), "Job Card Master Creation Failed")
-            
+            frappe.log_error(frappe.get_traceback(),"Job Card Master Creation Failed")
+             

--- a/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
+++ b/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
@@ -25,7 +25,6 @@
    "fieldname": "forwarder_name",
    "fieldtype": "Link",
    "hidden": 1,
-   "in_list_view": 1,
    "label": "Forwarder Name",
    "options": "Forwarder"
   },
@@ -98,6 +97,7 @@
   {
    "fieldname": "forwarder",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Forwarder",
    "options": "Supplier"
   }
@@ -106,7 +106,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:13:03.409995",
+ "modified": "2026-02-21 17:24:13.512603",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Forwarder Details",

--- a/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
+++ b/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
@@ -25,7 +25,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Forwarder Name",
-   "options": "Forwarder"
+   "options": "Supplier"
   },
   {
    "fieldname": "mode_of_transport",
@@ -98,7 +98,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-11 12:18:06.962721",
+ "modified": "2026-02-21 17:01:08.866948",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Forwarder Details",

--- a/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
+++ b/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
@@ -7,7 +7,6 @@
  "engine": "InnoDB",
  "field_order": [
   "forwarder",
-  "forwarder_name",
   "mode_of_transport",
   "origin",
   "destination",
@@ -21,13 +20,6 @@
   "remarks"
  ],
  "fields": [
-  {
-   "fieldname": "forwarder_name",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Forwarder Name",
-   "options": "Forwarder"
-  },
   {
    "fieldname": "mode_of_transport",
    "fieldtype": "Select",
@@ -106,7 +98,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:24:13.512603",
+ "modified": "2026-02-21 17:37:09.410224",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Forwarder Details",

--- a/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
+++ b/petropipe/petropipe/doctype/forwarder_details/forwarder_details.json
@@ -6,6 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "forwarder",
   "forwarder_name",
   "mode_of_transport",
   "origin",
@@ -23,9 +24,10 @@
   {
    "fieldname": "forwarder_name",
    "fieldtype": "Link",
+   "hidden": 1,
    "in_list_view": 1,
    "label": "Forwarder Name",
-   "options": "Supplier"
+   "options": "Forwarder"
   },
   {
    "fieldname": "mode_of_transport",
@@ -92,13 +94,19 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Remarks"
+  },
+  {
+   "fieldname": "forwarder",
+   "fieldtype": "Link",
+   "label": "Forwarder",
+   "options": "Supplier"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:01:08.866948",
+ "modified": "2026-02-21 17:13:03.409995",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Forwarder Details",

--- a/petropipe/petropipe/doctype/job_card_master/job_card_master.json
+++ b/petropipe/petropipe/doctype/job_card_master/job_card_master.json
@@ -11,7 +11,8 @@
   "incoterm",
   "column_break_mzvg",
   "company",
-  "sales_order"
+  "sales_order",
+  "grand_total"
  ],
  "fields": [
   {
@@ -54,12 +55,18 @@
    "label": "Company",
    "options": "Company",
    "read_only": 1
+  },
+  {
+   "fetch_from": "sales_order.grand_total",
+   "fieldname": "grand_total",
+   "fieldtype": "Currency",
+   "label": "Grand Total"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-11 10:34:14.352470",
+ "modified": "2026-02-21 16:58:41.107860",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Job Card Master",

--- a/petropipe/petropipe/doctype/production_processing_details/production_processing_details.json
+++ b/petropipe/petropipe/doctype/production_processing_details/production_processing_details.json
@@ -8,6 +8,7 @@
  "field_order": [
   "process_type",
   "description_of_work",
+  "vendor",
   "vendor_factory_name",
   "location",
   "qty",
@@ -71,6 +72,7 @@
   {
    "fieldname": "vendor_factory_name",
    "fieldtype": "Data",
+   "hidden": 1,
    "in_list_view": 1,
    "label": "Vendor/Factory  Name"
   },
@@ -91,13 +93,19 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Completion  Date"
+  },
+  {
+   "fieldname": "vendor",
+   "fieldtype": "Link",
+   "label": "Vendor",
+   "options": "Supplier"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-11 16:19:14.175838",
+ "modified": "2026-02-21 17:13:42.640576",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Production-Processing Details",

--- a/petropipe/petropipe/doctype/production_processing_details/production_processing_details.json
+++ b/petropipe/petropipe/doctype/production_processing_details/production_processing_details.json
@@ -73,7 +73,6 @@
    "fieldname": "vendor_factory_name",
    "fieldtype": "Data",
    "hidden": 1,
-   "in_list_view": 1,
    "label": "Vendor/Factory  Name"
   },
   {
@@ -97,6 +96,7 @@
   {
    "fieldname": "vendor",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Vendor",
    "options": "Supplier"
   }
@@ -105,7 +105,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:13:42.640576",
+ "modified": "2026-02-21 17:23:50.861916",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Production-Processing Details",

--- a/petropipe/petropipe/doctype/transporter_details/transporter_details.json
+++ b/petropipe/petropipe/doctype/transporter_details/transporter_details.json
@@ -7,7 +7,6 @@
  "engine": "InnoDB",
  "field_order": [
   "transporter",
-  "transporter_name",
   "type_transport",
   "pickup_location",
   "delivery_location",
@@ -63,13 +62,6 @@
    "label": "Remarks"
   },
   {
-   "fieldname": "transporter_name",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Transporter Name",
-   "options": "Transporter"
-  },
-  {
    "fieldname": "pickup_location",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -106,7 +98,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:24:33.173173",
+ "modified": "2026-02-21 17:36:59.122139",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Transporter Details",

--- a/petropipe/petropipe/doctype/transporter_details/transporter_details.json
+++ b/petropipe/petropipe/doctype/transporter_details/transporter_details.json
@@ -66,7 +66,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Transporter Name",
-   "options": "Transporter"
+   "options": "Supplier"
   },
   {
    "fieldname": "pickup_location",
@@ -98,7 +98,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-11 15:27:02.301262",
+ "modified": "2026-02-21 17:01:35.313114",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Transporter Details",

--- a/petropipe/petropipe/doctype/transporter_details/transporter_details.json
+++ b/petropipe/petropipe/doctype/transporter_details/transporter_details.json
@@ -6,6 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "transporter",
   "transporter_name",
   "type_transport",
   "pickup_location",
@@ -64,9 +65,10 @@
   {
    "fieldname": "transporter_name",
    "fieldtype": "Link",
+   "hidden": 1,
    "in_list_view": 1,
    "label": "Transporter Name",
-   "options": "Supplier"
+   "options": "Transporter"
   },
   {
    "fieldname": "pickup_location",
@@ -92,13 +94,19 @@
    "in_list_view": 1,
    "label": "Transport  Type",
    "options": "\nAir\nSea"
+  },
+  {
+   "fieldname": "transporter",
+   "fieldtype": "Link",
+   "label": "Transporter",
+   "options": "Supplier"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:01:35.313114",
+ "modified": "2026-02-21 17:12:17.324919",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Transporter Details",

--- a/petropipe/petropipe/doctype/transporter_details/transporter_details.json
+++ b/petropipe/petropipe/doctype/transporter_details/transporter_details.json
@@ -66,7 +66,6 @@
    "fieldname": "transporter_name",
    "fieldtype": "Link",
    "hidden": 1,
-   "in_list_view": 1,
    "label": "Transporter Name",
    "options": "Transporter"
   },
@@ -98,6 +97,7 @@
   {
    "fieldname": "transporter",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Transporter",
    "options": "Supplier"
   }
@@ -106,7 +106,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-21 17:12:17.324919",
+ "modified": "2026-02-21 17:24:33.173173",
  "modified_by": "Administrator",
  "module": "Petropipe",
  "name": "Transporter Details",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grand Total added to Job Card Master, auto-populated from linked Sales Orders.

* **Bug Fixes**
  * Job Card Master creation now gracefully handles duplicates by updating existing records instead of failing.

* **Changes**
  * Forwarder, Transporter, and Vendor now use Supplier link fields; corresponding legacy name fields hidden/removed and field ordering adjusted for cleaner forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->